### PR TITLE
add a default function to Deed contract

### DIFF
--- a/HashRegistrar.sol
+++ b/HashRegistrar.sol
@@ -93,6 +93,9 @@ contract Deed {
         if(owner.send(this.balance)) 
             selfdestruct(burn);
     }
+
+    /* The default function just receives an amount */
+    function () {}
 }
 
 contract Registrar {


### PR DESCRIPTION
Since `Registrar` contract contains an expression `newBid.send(msg.value)` for a `Deed newBid`, the `Deed` contract needs a fallback function.  This pull-request adds a fallback function that just returns.