### PR TITLE
Possibly more correct `renewalDate` computation

### DIFF
--- a/HashRegistrar.sol
+++ b/HashRegistrar.sol
@@ -344,7 +344,8 @@ contract Registrar {
         h.value = updatedPrice;
         h.lastRenewed = now;
         // Twice the current age, as long as it's betwen some max and min parameters
-        uint renewalDate = min(2 * now - h.registrationDate, now + maxRenewalPeriod);
+        uint currentAge = now - h.registrationDate;
+        uint renewalDate = now + min(2 * currentAge, maxRenewalPeriod);
         h.renewalDate = max(renewalDate, h.registrationDate + renewalPeriod);
         h.averagePrice = averagePrice;
     }


### PR DESCRIPTION
The `renewalDate` computation contained an expression `2 * now - h.registrationDate`.  Supposing `now` is year 3000 (the code should still work in the 30th century), this expression evaluates somewhere around year 4030.

This commit tries to figure out the original intent.