### PR TITLE
Preventing subtraction underflow in slowStart

### DIFF
--- a/HashRegistrar.sol
+++ b/HashRegistrar.sol
@@ -177,7 +177,9 @@ contract Registrar {
         }
         
         // for the first six months of the registry, make longer auctions
-        uint slowStart = 1 + (registryCreated + 20 weeks - now) / 4 weeks;
+        uint slowStart =
+          (now <= registryCreated + 20 weeks) ?
+          (1 + (registryCreated + 20 weeks - now) / 4 weeks) : 1;
         newAuction.registrationDate = now + auctionLength * slowStart;
         newAuction.status = Mode.Auction;  
         newAuction.value = 0;

--- a/HashRegistrar.sol
+++ b/HashRegistrar.sol
@@ -176,7 +176,7 @@ contract Registrar {
             deedContract.closeDeed(999);
         }
         
-        // for the first six months of the registry, make longer auctions
+        // for the first five months of the registry, make longer auctions
         uint slowStart =
           (now <= registryCreated + 20 weeks) ?
           (1 + (registryCreated + 20 weeks - now) / 4 weeks) : 1;


### PR DESCRIPTION
Before this pull-request, the computation of `slowStart` contained a subtraction that can underflow:
```
registryCreated + 20 weeks - now
```
when the current timestamp is more than 20 weeks after the registry creation.  In unlucky cases the `newAuction.registrationDate` would become a point in the past.  This pull request avoids the subtraction when the underflow would occur.

I hope this time it's not an arithmetic misconception (like the one I made in #3).