### PR TITLE
Remove a @param comment that describes a non-existing parameter

### DIFF
--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -77,7 +77,6 @@ contract Deed {
 
     /**
      * @dev Close a deed and refund a specified fraction of the bid value
-     * @param refundRatio The amount*1/1000 to refund
      */
     function destroyDeed() {
         if (active) throw;


### PR DESCRIPTION
`destroyDeed()` function takes no arguments but there was a @param comment describing an argument.  This was caught by the `develop` version of `solc`.